### PR TITLE
Remove unnecessary " in version.py

### DIFF
--- a/pymp2rage/version.py
+++ b/pymp2rage/version.py
@@ -20,7 +20,7 @@ __version__ = '.'.join(map(str, _ver))
 CLASSIFIERS = ["Development Status :: 3 - Alpha",
                "Environment :: Console",
                "Intended Audience :: Science/Research",
-               "License :: OSI Approved :: Apache License, 2.0"",
+               "License :: OSI Approved :: Apache License, 2.0",
                "Operating System :: OS Independent",
                "Programming Language :: Python",
                "Topic :: Scientific/Engineering"]


### PR DESCRIPTION
The `pip install` fails because of a " in the version.py file.

```cmd
(base) C:\Users\gaspa\GitHub\pymp2rage>pip install -e .
Obtaining file:///C:/Users/gaspa/GitHub/pymp2rage
    ERROR: Command errored out with exit status 1:
     command: 'C:\Users\gaspa\miniconda3\python.exe' -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\gaspa\\GitHub\\pymp2rage\\setup.py'"'"'; __file__='"'"'C:\\Users\\gaspa\\GitHub\\pymp2rage\\setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base 'C:\Users\gaspa\AppData\Local\Temp\pip-pip-egg-info-idgyu01r'
         cwd: C:\Users\gaspa\GitHub\pymp2rage\
    Complete output (8 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\gaspa\GitHub\pymp2rage\setup.py", line 8, in <module>
        exec(f.read())
      File "<string>", line 23
        "License :: OSI Approved :: Apache License, 2.0"",
                                                         ^
    SyntaxError: EOL while scanning string literal
    ----------------------------------------
```